### PR TITLE
Inline tray icon for shell

### DIFF
--- a/shell/README.md
+++ b/shell/README.md
@@ -1,0 +1,15 @@
+# Sentient Shell
+
+This directory contains the Electron shell used to display the tray icon.
+
+The tray icon is embedded directly in `main.js` as a base64 string so the
+application does not rely on external files. To regenerate the icon or to
+experiment with new ones, run `generate_icon.py`:
+
+```bash
+python3 generate_icon.py > new_icon.b64
+```
+
+Copy the printed string into `main.js` after `data:image/png;base64,` to update
+the icon. The current script creates a 1×1 pixel PNG. Feel free to modify it to
+produce a more elaborate icon.

--- a/shell/generate_icon.py
+++ b/shell/generate_icon.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Generate the tray icon and print its base64 representation."""
+import base64
+from io import BytesIO
+
+try:
+    from PIL import Image
+except ImportError:  # pragma: no cover - pillow may not be installed
+    raise SystemExit("Install pillow: pip install pillow")
+
+# Create a 1x1 white pixel PNG
+img = Image.new("RGBA", (1, 1), (255, 255, 255, 0))
+buffer = BytesIO()
+img.save(buffer, format="PNG")
+
+data = buffer.getvalue()
+encoded = base64.b64encode(data).decode("utf-8")
+print(encoded)

--- a/shell/main.js
+++ b/shell/main.js
@@ -1,0 +1,18 @@
+const { app, Tray, nativeImage } = require('electron');
+
+// Base64 encoded 1x1 PNG used for the tray icon.
+// Regenerate using `python3 generate_icon.py` or see README for instructions.
+const iconDataURL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==';
+
+let tray = null;
+
+app.whenReady().then(() => {
+  const image = nativeImage.createFromDataURL(iconDataURL);
+  tray = new Tray(image);
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/shell/package.json
+++ b/shell/package.json
@@ -2,7 +2,7 @@
   "name": "sentient-shell",
   "version": "0.1.0",
   "description": "Electron front-end for Sentient",
-  "main": "index.js",
+  "main": "main.js",
   "scripts": {
     "start": "electron ."
   }


### PR DESCRIPTION
## Summary
- create a minimal Electron main process that embeds the tray icon as base64
- add helper script to regenerate the icon
- document regeneration steps in README
- configure package.json to load `main.js`

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*