### PR TITLE
Add vcrpy dev dependency

### DIFF
--- a/ingestion/pyproject.toml
+++ b/ingestion/pyproject.toml
@@ -8,6 +8,7 @@ authors = ["Sentient Team <team@example.com>"]
 python = "^3.10"
 
 [tool.poetry.dev-dependencies]
+vcrpy = "^5.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
## Summary
- include `vcrpy` as a dev dependency for the ingestion project

## Testing
- `pytest ingestion/calendar/tests/test_plugin.py -q` *(fails: command not found)*